### PR TITLE
chore: "Implement Google AdSense via nginx in Docker"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ENV TZ=Asia/Taipei \
     TMT_PORT=26670
 
 COPY ./dist /usr/share/nginx/html/tmt-dist
+COPY ./ads.txt /usr/share/nginx/adsense/ads.txt
 COPY ./nginx.conf /etc/nginx/nginx.conf
 COPY ./scripts/entry_point.sh /usr/share/nginx/html/entry_point.sh
 

--- a/ads.txt
+++ b/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-1617900048851450, DIRECT, f08c47fec0942fa0

--- a/nginx.conf
+++ b/nginx.conf
@@ -67,6 +67,10 @@ http {
             alias /var/www/android/;
         }
 
+        location /ads.txt {
+            alias /usr/share/nginx/adsense/ads.txt;
+        }
+
         location / {
             root /usr/share/nginx/html/tmt-dist;
             index index.html;


### PR DESCRIPTION
- Add a copy command to the Dockerfile for `ads.txt` into the nginx adsense directory
- Create a new file `ads.txt` with Google AdSense details
- Configure nginx to serve the `ads.txt` file at the `/ads.txt` path