### PR TITLE
feat: "Extend route condition in Vite configuration"

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,7 +25,8 @@ export default defineConfig({
     Vue(),
     Pages({
       extendRoute: (route) => {
-        if (route.path === "/login") {
+        const path = route.path as string;
+        if (path === "/login" || path.startsWith("/user/verify")) {
           return route;
         }
         if (!route.meta) route.meta = {};


### PR DESCRIPTION
- In the Vite configuration, extend the route condition to include path starting with `/user/verify` in addition to `/login`.