### PR TITLE
chore: "Update dependencies and adjust import paths"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "toc-fronted-web",
       "version": "0.0.1",
       "dependencies": {
-        "@chindada/toc-trade-protobuf": "^0.1.7",
+        "@chindada/toc-trade-protobuf": "^0.1.9",
         "@syncfusion/ej2-vue-charts": "^25.2.4",
-        "axios": "^1.6.8",
+        "axios": "^1.7.0",
         "firebase": "^10.12.0",
         "pinia": "^2.1.7",
         "primeflex": "^3.3.1",
@@ -310,9 +310,9 @@
       }
     },
     "node_modules/@chindada/toc-trade-protobuf": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@chindada/toc-trade-protobuf/-/toc-trade-protobuf-0.1.7.tgz",
-      "integrity": "sha512-XjOVhsD4n+Q9Ea5Qtmgk5aEm8e7L4FccQlS4E1W03N6mtWd5z7Z/1bu0He3SXHMhWEcVSjbfBHWXJNaGrxXZJw==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@chindada/toc-trade-protobuf/-/toc-trade-protobuf-0.1.9.tgz",
+      "integrity": "sha512-JenIhgFYq83WkrO5RX+R3KtChMyeJMpObyJ3+8mYsKdBLrpxklouZ5g6gSvfhMXwpnE5L6acUHMuint9CnrvJA==",
       "dependencies": {
         "@types/google-protobuf": "^3.15.12",
         "google-protobuf": "^3.21.2"
@@ -3080,9 +3080,9 @@
       "dev": true
     },
     "node_modules/axios": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
-      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.0.tgz",
+      "integrity": "sha512-IiB0wQeKyPRdsFVhBgIo31FbzOyf2M6wYl7/NVutFwFBRMiAbjNiydJIHKeLmPugF4kJLfA1uWZ82Is2QzqqFA==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
-    "@chindada/toc-trade-protobuf": "^0.1.7",
+    "@chindada/toc-trade-protobuf": "^0.1.9",
     "@syncfusion/ej2-vue-charts": "^25.2.4",
-    "axios": "^1.6.8",
+    "axios": "^1.7.0",
     "firebase": "^10.12.0",
     "pinia": "^2.1.7",
     "primeflex": "^3.3.1",

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -2,7 +2,7 @@
 import {
   StockVolumeRankMessage,
   StockVolumeRankResponse
-} from "@chindada/toc-trade-protobuf/src/ts/forwarder/realtime";
+} from "@chindada/toc-trade-protobuf/typescript/forwarder/realtime";
 import { onMounted, ref } from "vue";
 
 const stocks = ref<StockVolumeRankMessage[]>([]);

--- a/src/pages/realtime/future.vue
+++ b/src/pages/realtime/future.vue
@@ -3,9 +3,9 @@ import { GetNearestMXF } from "@/apis/basic/search";
 import {
   TradeIndex,
   WSMessage
-} from "@chindada/toc-trade-protobuf/src/ts/app/app";
-import type { FutureDetailMessage } from "@chindada/toc-trade-protobuf/src/ts/forwarder/basic";
-import { FutureRealTimeTickMessage } from "@chindada/toc-trade-protobuf/src/ts/forwarder/mq";
+} from "@chindada/toc-trade-protobuf/typescript/app/app";
+import type { FutureDetailMessage } from "@chindada/toc-trade-protobuf/typescript/forwarder/basic";
+import { FutureRealTimeTickMessage } from "@chindada/toc-trade-protobuf/typescript/forwarder/mq";
 import {
   CandleSeries,
   Category,


### PR DESCRIPTION
- Update `@chindada/toc-trade-protobuf` dependency version from `0.1.7` to `0.1.9`
- Update `axios` dependency version from `1.6.8` to `1.7.0`
- Change import path of `@chindada/toc-trade-protobuf` from `src/ts` to `typescript` in `index.vue` and `future.vue` files