### PR TITLE
chore: downgrade Syncfusion dependencies and update script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "@chindada/toc-trade-protobuf": "^0.1.11",
-    "@syncfusion/ej2-base": "^27.1.50",
-    "@syncfusion/ej2-vue-charts": "^27.1.50",
+    "@syncfusion/ej2-base": "^25.2.7",
+    "@syncfusion/ej2-vue-charts": "^25.2.6",
     "axios": "^1.7.7",
     "firebase": "^10.13.2",
     "pinia": "^2.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,11 +12,11 @@ importers:
         specifier: ^0.1.11
         version: 0.1.11
       '@syncfusion/ej2-base':
-        specifier: ^27.1.50
-        version: 27.1.50
+        specifier: ^25.2.7
+        version: 25.2.7
       '@syncfusion/ej2-vue-charts':
-        specifier: ^27.1.50
-        version: 27.1.50
+        specifier: ^25.2.6
+        version: 25.2.6
       axios:
         specifier: ^1.7.7
         version: 1.7.7(debug@4.3.7)
@@ -768,60 +768,60 @@ packages:
   '@sideway/pinpoint@2.0.0':
     resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
 
-  '@syncfusion/ej2-base@27.1.50':
-    resolution: {integrity: sha512-2NOGikrj+XoGRgq4HBSBRe1lEMN2ORRyARaoufF7GzffvTrIKGpScE69z6C/zASPIX5IDcvcZA0MHVD4B3XIrg==}
+  '@syncfusion/ej2-base@25.2.7':
+    resolution: {integrity: sha512-sbZ8IVEg4UkD5wXV3GXLyoH6q4sYpCVP3HJ1FwlJ+/+rgAQ2h7NaQhBmljg0o+ZfXEB7UuIZ59AzNQqc0eL6Eg==}
     hasBin: true
 
-  '@syncfusion/ej2-buttons@27.1.50':
-    resolution: {integrity: sha512-v5q/ELNduED13F0XuoGuAWhjlAOtPvigVwC0VqxjgEglEbofMvwED2qHOcsOZOFRn22KT/NEDBiUx2L5NFO9EQ==}
+  '@syncfusion/ej2-buttons@25.2.7':
+    resolution: {integrity: sha512-Jn+YN83XKH+sEWy1s8FVKVaiQZxwDf+Rwf2JxCNzIEz1cZA9HV8NT/W0YuxwFIoXBaz11OOiqG4ETqLE8JtX0Q==}
 
-  '@syncfusion/ej2-calendars@27.1.50':
-    resolution: {integrity: sha512-DnSKjU3D8/zYudB4ZhgXWdBu2v2e39MOyO28KbJVZfme+AToJ/0x/pmQfMLi6sHxvFHpHSB8MjByQc54szrrqQ==}
+  '@syncfusion/ej2-calendars@25.2.7':
+    resolution: {integrity: sha512-326chJiUu3tAKCVnyiUYihQyNH20FMgyg87fQSa6G7aGVL1F1/70GAlmX/FU+6Flub+6Ki6LZzfIhD2xsPvS8g==}
 
-  '@syncfusion/ej2-charts@27.1.50':
-    resolution: {integrity: sha512-IbWf17aoYm22gmFtit4tgYRZXx4oeto7X5bAW4j73dW+nvfzGD9QKo0G+s0aGGbS+FWyP1Oq0m2ljfz8X3OZDQ==}
+  '@syncfusion/ej2-charts@25.2.6':
+    resolution: {integrity: sha512-G8xUF85BuXK1NYnPoS4SMa7oxHbMdr384cHkLZ8CMtAzgyh+9qQeyV5EJPqvSeaz4b8FY2h4/FC/tWaXNQTv4w==}
 
-  '@syncfusion/ej2-compression@27.1.50':
-    resolution: {integrity: sha512-uvDUKjBUt4SNE2L5tL0r1X2uMmDIYui9Mq6cqQFZvieXJg2awc+873N9KQ6f+9U4aYZ9LWSy1eU0pTJqd8j6AQ==}
+  '@syncfusion/ej2-compression@25.2.3':
+    resolution: {integrity: sha512-fDlsQcLUb0jhB2JgZJ6wGJ8DkwEU74F/AX07IYZCzHXRCVvLL1UEZEaR3lA6YLqoMit3UWJZv9Di1fhhwMfdKg==}
 
-  '@syncfusion/ej2-data@27.1.50':
-    resolution: {integrity: sha512-MuXYHkd93qk97elaeAbA5scjfneD2/96vlLDmAxXTzeg34FZHJQVyBg/9HkZtk/M7YiNawSXXAF3m6D3bVm5xQ==}
+  '@syncfusion/ej2-data@25.2.3':
+    resolution: {integrity: sha512-lzULJdW4ok79opA+FGppfPx1nUGiDwIA2KGr8XBOLmShW1o+Jt+KNOx3EVkW2r3VqRX3E0Pg5OlNk3uHFPe7sw==}
 
-  '@syncfusion/ej2-excel-export@27.1.50':
-    resolution: {integrity: sha512-UfTLxFshWbKumLMm55SC92yrCthNeUt0pFemqbXMJ6ZnUF9+Rb0LFkG/DMtqjkx1vVAcMqBxYMNShB7awXiShw==}
+  '@syncfusion/ej2-excel-export@25.2.3':
+    resolution: {integrity: sha512-5ctlageHY4m/ox4Y5LGsWcwCIR+B/zZ7ZE0nExh09LH9N/C3lofBUlpV/sdS5cQDA5aEhhO2MT+n4IPNBzLSwA==}
 
-  '@syncfusion/ej2-file-utils@27.1.50':
-    resolution: {integrity: sha512-DK2DpCBT2Wyt5UhtrTzqoWYp4rTYHHqKqdBBAhSAhXtbITzDlmt3HgH4ZhrPmCXPz0XYnOmiEqO/ejFjZ/uRiw==}
+  '@syncfusion/ej2-file-utils@25.2.3':
+    resolution: {integrity: sha512-Ju+U6jmDx+PMiyKWkv/jLWWXKp1+N+ym7TlEUBZguYR0/tuqedHDhliL9/R4ZhMGpwlB9oBFwX4+5VgJzdk0yA==}
 
-  '@syncfusion/ej2-icons@27.1.50':
-    resolution: {integrity: sha512-LisXluEss0VnFuSh+pNSgHqT/Cg1FKTvkxdKWoSvqAma3dpcuCfrWP4svyMKPAsCi/hxAGdyy3ShKHu0PUP9iA==}
+  '@syncfusion/ej2-icons@25.2.3':
+    resolution: {integrity: sha512-WptrAR3YShA8S+mushGCojRmBgLUCYpsYq1Nw1S1ynWNRcijlZgdil5L7LjaGA8H6CA/mFG5BMBDCmZ76hYX1A==}
 
-  '@syncfusion/ej2-inputs@27.1.50':
-    resolution: {integrity: sha512-JO+J5hl62YGWddsHyZBfwQ2K1iCLHlut6rhHvyCgcOIV+0yXi1j6ZwW2ouc0+0aLeXHm7hLpdMhVX8zGMzRb6A==}
+  '@syncfusion/ej2-inputs@25.2.6':
+    resolution: {integrity: sha512-DjhOU6ZH55JA92zb2PORSRPui6xBrx4VKQFO0Pkb2kVNixFK2AvmeeGMG33i+GdECLBFI5Vevl/qaQ+kttBwkg==}
 
-  '@syncfusion/ej2-lists@27.1.50':
-    resolution: {integrity: sha512-CbTdJz4pz9k+/sYTeT5xJ6VZDKGzo9KF7oEeOqhXjRNm1qQd5ANonxsuOVAWLojJwhKQcfQxGTVrOjE/D+YBoA==}
+  '@syncfusion/ej2-lists@25.2.3':
+    resolution: {integrity: sha512-IunnsCjkHsDRMOgJ20wclxpB0UJsDDwsLTwlNqIi6ddDkluBmZBlviS8Zb16YthUO020YNTLN10HgP7JRevvlA==}
 
-  '@syncfusion/ej2-navigations@27.1.50':
-    resolution: {integrity: sha512-dQM4o+2uCU7d+rCzfjphuDSwt98UVDfdHspe70Ev2S/dPgynIG8093tz5gDOdRC1gQEVRXFY116NClPDF1KtKQ==}
+  '@syncfusion/ej2-navigations@25.2.6':
+    resolution: {integrity: sha512-tTDrGdbEAsk26BdEzj2ufGGpeNXwNfy3exrDIZs9cyUpX8YdUASRoCJBuUkwrHIs2NQe1Ds6M/AIQrZKv7SBBw==}
 
-  '@syncfusion/ej2-pdf-export@27.1.50':
-    resolution: {integrity: sha512-UEJbTCnk+KI+Knc5QC7MjrKESsrCr0/CydU0zZv+LNS0h30/XgUACdDq55+Z0GJIK7vUiBE+vkVMttwZ2c70sA==}
+  '@syncfusion/ej2-pdf-export@25.2.3':
+    resolution: {integrity: sha512-2TN6YbkPrvqGX3CQUMgUq/rQ0995POMoUiTklIxK7ylmIvD6Wc0gtKsHnEqepUN59s89Uxj4fKw/g5U+cB2kcA==}
 
-  '@syncfusion/ej2-popups@27.1.50':
-    resolution: {integrity: sha512-CbG9/0JgjvJfb5JwmbTXluRkLGZsGFAQ4b86FzQw/467Oom6JHto0K8qkgfR4t7Ekng1WSycHDSQF7t3QIQL3w==}
+  '@syncfusion/ej2-popups@25.2.7':
+    resolution: {integrity: sha512-H8nVRXE7kkifZgif6bjs3POS+f7FZQPf7cTZog+OP526guDMWfKTbxNlRmpcRLSG5wvnFn340/KEVRVjeLpRLw==}
 
-  '@syncfusion/ej2-splitbuttons@27.1.50':
-    resolution: {integrity: sha512-P8wIL88b/PS7tG6VACiJp/fg9321ONpNZnmI+5suKFW/V2U3NzhYh1yFv0gi79s70Aomu+mjMcre07AZu4U+VQ==}
+  '@syncfusion/ej2-splitbuttons@25.2.4':
+    resolution: {integrity: sha512-9C3sXLg9+fCJPX3tdQPKUJfxMw7FKFm4lLRGHliSVqbnK6dsSw2NzR8yt5gtTDgQgSGCCwL87e9g1QCAc7GTAQ==}
 
-  '@syncfusion/ej2-svg-base@27.1.50':
-    resolution: {integrity: sha512-SCX38cHp1aHdZoTQbFBotbBpZfYW8Qs9tm15j8ylNXVJ/w+kkjy4JjrZUIkjImDmfxVL5BP9dw/INMRaRaRLBQ==}
+  '@syncfusion/ej2-svg-base@25.2.5':
+    resolution: {integrity: sha512-EPsZ1cuCqnYaAKL7gE1OoKDzJ1PWSTXF7Dzgnx8aR8sJ7frIiBDE5/Qau+H/mWDHs4hmU5dWAGU2QaedgWkyRg==}
 
-  '@syncfusion/ej2-vue-base@27.1.50':
-    resolution: {integrity: sha512-ltXnhLD9kJGwBOLRlK73gmjOmiBhotTpbYHIRu3V4yMJyRJJpa0MheG8X6SZvaXX6l+gvMadbF6X4pFXOqSQCQ==}
+  '@syncfusion/ej2-vue-base@25.2.4':
+    resolution: {integrity: sha512-dngL7QId0nPvLl9OTIHYxt0Po9jHE+bt3BaWZk0E3fGv+o1v2gMr752tBWpPnvNMoaEAyFOxNl4afYIvbgpTUA==}
 
-  '@syncfusion/ej2-vue-charts@27.1.50':
-    resolution: {integrity: sha512-A1VDao/zDuGKWOLszGY0jBrYKe+dGVV3B41X1U1tBHwJP4mTMUV2+3gv2y5DGyhLZ4wlt8qGrXVK3f2oSAQ8Mw==}
+  '@syncfusion/ej2-vue-charts@25.2.6':
+    resolution: {integrity: sha512-vB9Ct9/1307hnmJhrP4AiThTE9deFhtZC9xrqqGnQQyZ+jKHnX4F4RTdXRPB9eUvX/GOhxWbJ3J1c1TAdu7TSw==}
 
   '@trivago/prettier-plugin-sort-imports@4.3.0':
     resolution: {integrity: sha512-r3n0onD3BTOVUNPhR4lhVK4/pABGpbA7bW3eumZnYdKaHkf1qEC+Mag6DPbGNuuh0eG8AaYj+YqmVHSiGslaTQ==}
@@ -3584,99 +3584,99 @@ snapshots:
 
   '@sideway/pinpoint@2.0.0': {}
 
-  '@syncfusion/ej2-base@27.1.50':
+  '@syncfusion/ej2-base@25.2.7':
     dependencies:
-      '@syncfusion/ej2-icons': 27.1.50
+      '@syncfusion/ej2-icons': 25.2.3
 
-  '@syncfusion/ej2-buttons@27.1.50':
+  '@syncfusion/ej2-buttons@25.2.7':
     dependencies:
-      '@syncfusion/ej2-base': 27.1.50
+      '@syncfusion/ej2-base': 25.2.7
 
-  '@syncfusion/ej2-calendars@27.1.50':
+  '@syncfusion/ej2-calendars@25.2.7':
     dependencies:
-      '@syncfusion/ej2-base': 27.1.50
-      '@syncfusion/ej2-buttons': 27.1.50
-      '@syncfusion/ej2-inputs': 27.1.50
-      '@syncfusion/ej2-lists': 27.1.50
-      '@syncfusion/ej2-popups': 27.1.50
+      '@syncfusion/ej2-base': 25.2.7
+      '@syncfusion/ej2-buttons': 25.2.7
+      '@syncfusion/ej2-inputs': 25.2.6
+      '@syncfusion/ej2-lists': 25.2.3
+      '@syncfusion/ej2-popups': 25.2.7
 
-  '@syncfusion/ej2-charts@27.1.50':
+  '@syncfusion/ej2-charts@25.2.6':
     dependencies:
-      '@syncfusion/ej2-base': 27.1.50
-      '@syncfusion/ej2-calendars': 27.1.50
-      '@syncfusion/ej2-data': 27.1.50
-      '@syncfusion/ej2-excel-export': 27.1.50
-      '@syncfusion/ej2-navigations': 27.1.50
-      '@syncfusion/ej2-pdf-export': 27.1.50
-      '@syncfusion/ej2-svg-base': 27.1.50
+      '@syncfusion/ej2-base': 25.2.7
+      '@syncfusion/ej2-calendars': 25.2.7
+      '@syncfusion/ej2-data': 25.2.3
+      '@syncfusion/ej2-excel-export': 25.2.3
+      '@syncfusion/ej2-navigations': 25.2.6
+      '@syncfusion/ej2-pdf-export': 25.2.3
+      '@syncfusion/ej2-svg-base': 25.2.5
 
-  '@syncfusion/ej2-compression@27.1.50':
+  '@syncfusion/ej2-compression@25.2.3':
     dependencies:
-      '@syncfusion/ej2-file-utils': 27.1.50
+      '@syncfusion/ej2-file-utils': 25.2.3
 
-  '@syncfusion/ej2-data@27.1.50':
+  '@syncfusion/ej2-data@25.2.3':
     dependencies:
-      '@syncfusion/ej2-base': 27.1.50
+      '@syncfusion/ej2-base': 25.2.7
 
-  '@syncfusion/ej2-excel-export@27.1.50':
+  '@syncfusion/ej2-excel-export@25.2.3':
     dependencies:
-      '@syncfusion/ej2-base': 27.1.50
-      '@syncfusion/ej2-compression': 27.1.50
+      '@syncfusion/ej2-base': 25.2.7
+      '@syncfusion/ej2-compression': 25.2.3
 
-  '@syncfusion/ej2-file-utils@27.1.50': {}
+  '@syncfusion/ej2-file-utils@25.2.3': {}
 
-  '@syncfusion/ej2-icons@27.1.50': {}
+  '@syncfusion/ej2-icons@25.2.3': {}
 
-  '@syncfusion/ej2-inputs@27.1.50':
+  '@syncfusion/ej2-inputs@25.2.6':
     dependencies:
-      '@syncfusion/ej2-base': 27.1.50
-      '@syncfusion/ej2-buttons': 27.1.50
-      '@syncfusion/ej2-popups': 27.1.50
-      '@syncfusion/ej2-splitbuttons': 27.1.50
+      '@syncfusion/ej2-base': 25.2.7
+      '@syncfusion/ej2-buttons': 25.2.7
+      '@syncfusion/ej2-popups': 25.2.7
+      '@syncfusion/ej2-splitbuttons': 25.2.4
 
-  '@syncfusion/ej2-lists@27.1.50':
+  '@syncfusion/ej2-lists@25.2.3':
     dependencies:
-      '@syncfusion/ej2-base': 27.1.50
-      '@syncfusion/ej2-buttons': 27.1.50
-      '@syncfusion/ej2-data': 27.1.50
-      '@syncfusion/ej2-popups': 27.1.50
+      '@syncfusion/ej2-base': 25.2.7
+      '@syncfusion/ej2-buttons': 25.2.7
+      '@syncfusion/ej2-data': 25.2.3
+      '@syncfusion/ej2-popups': 25.2.7
 
-  '@syncfusion/ej2-navigations@27.1.50':
+  '@syncfusion/ej2-navigations@25.2.6':
     dependencies:
-      '@syncfusion/ej2-base': 27.1.50
-      '@syncfusion/ej2-buttons': 27.1.50
-      '@syncfusion/ej2-data': 27.1.50
-      '@syncfusion/ej2-inputs': 27.1.50
-      '@syncfusion/ej2-lists': 27.1.50
-      '@syncfusion/ej2-popups': 27.1.50
+      '@syncfusion/ej2-base': 25.2.7
+      '@syncfusion/ej2-buttons': 25.2.7
+      '@syncfusion/ej2-data': 25.2.3
+      '@syncfusion/ej2-inputs': 25.2.6
+      '@syncfusion/ej2-lists': 25.2.3
+      '@syncfusion/ej2-popups': 25.2.7
 
-  '@syncfusion/ej2-pdf-export@27.1.50':
+  '@syncfusion/ej2-pdf-export@25.2.3':
     dependencies:
-      '@syncfusion/ej2-compression': 27.1.50
+      '@syncfusion/ej2-compression': 25.2.3
 
-  '@syncfusion/ej2-popups@27.1.50':
+  '@syncfusion/ej2-popups@25.2.7':
     dependencies:
-      '@syncfusion/ej2-base': 27.1.50
-      '@syncfusion/ej2-buttons': 27.1.50
+      '@syncfusion/ej2-base': 25.2.7
+      '@syncfusion/ej2-buttons': 25.2.7
 
-  '@syncfusion/ej2-splitbuttons@27.1.50':
+  '@syncfusion/ej2-splitbuttons@25.2.4':
     dependencies:
-      '@syncfusion/ej2-base': 27.1.50
-      '@syncfusion/ej2-popups': 27.1.50
+      '@syncfusion/ej2-base': 25.2.7
+      '@syncfusion/ej2-popups': 25.2.7
 
-  '@syncfusion/ej2-svg-base@27.1.50':
+  '@syncfusion/ej2-svg-base@25.2.5':
     dependencies:
-      '@syncfusion/ej2-base': 27.1.50
+      '@syncfusion/ej2-base': 25.2.7
 
-  '@syncfusion/ej2-vue-base@27.1.50':
+  '@syncfusion/ej2-vue-base@25.2.4':
     dependencies:
-      '@syncfusion/ej2-base': 27.1.50
+      '@syncfusion/ej2-base': 25.2.7
 
-  '@syncfusion/ej2-vue-charts@27.1.50':
+  '@syncfusion/ej2-vue-charts@25.2.6':
     dependencies:
-      '@syncfusion/ej2-base': 27.1.50
-      '@syncfusion/ej2-charts': 27.1.50
-      '@syncfusion/ej2-vue-base': 27.1.50
+      '@syncfusion/ej2-base': 25.2.7
+      '@syncfusion/ej2-charts': 25.2.6
+      '@syncfusion/ej2-vue-base': 25.2.4
 
   '@trivago/prettier-plugin-sort-imports@4.3.0(@vue/compiler-sfc@3.5.8)(prettier@3.3.3)':
     dependencies:

--- a/scripts/update_dependency.sh
+++ b/scripts/update_dependency.sh
@@ -7,8 +7,8 @@ rm -rf pnpm-lock.yaml
 
 pnpm i
 npm i -g npm-check-updates
-ncu --reject primevue --peer -u
-ncu --peer -u -t minor -f primevue
+ncu --reject primevue,@syncfusion/ej2-base,@syncfusion/ej2-vue-charts --peer -u
+ncu --peer -u -t minor -f primevue,@syncfusion/ej2-base,@syncfusion/ej2-vue-charts
 
 pnpm i
 pnpm build


### PR DESCRIPTION
- Downgrade `@syncfusion/ej2-base` dependency from `27.1.50` to `25.2.7`
- Downgrade `@syncfusion/ej2-vue-charts` dependency from `27.1.50` to `25.2.6`
- Update dependency update script to reject and handle `@syncfusion/ej2-base` and `@syncfusion/ej2-vue-charts`